### PR TITLE
Fix npm install mistake in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ git clone git@github.com:fubhy/drupal-decoupled-app
 Then, you need to install the dependencies.
 
 ``
-npm run install
+npm install
 ``
 
 Now you can run the application.


### PR DESCRIPTION
I got an error with `npm run install`. Think we mean `npm install`